### PR TITLE
Hotfix: Prevent changelog automation self-trigger loop

### DIFF
--- a/.github/workflows/changelog-automation.yml
+++ b/.github/workflows/changelog-automation.yml
@@ -3,6 +3,8 @@ name: 📝 Changelog Automation
 on:
   push:
     branches: [main, initial-setup]
+    paths-ignore:
+      - 'CHANGELOG.md'
   pull_request_target:
     types: [closed]
     branches: [main, initial-setup]


### PR DESCRIPTION
Fix prevents changelog automation from triggering itself when CHANGELOG.md is updated.

Adds paths-ignore for CHANGELOG.md to the push trigger.