### PR TITLE
fix: stop weekly changelog PR churn

### DIFF
--- a/.github/workflows/changelog-automation.yml
+++ b/.github/workflows/changelog-automation.yml
@@ -6,9 +6,6 @@ on:
     branches: [main, initial-setup]
   release:
     types: [created, published]
-  schedule:
-    # Update changelog weekly on Sundays at 3 AM UTC
-    - cron: '0 3 * * 0'
   workflow_dispatch:
     inputs:
       version:

--- a/docs/REPOSITORY_STRUCTURE_ANALYSIS.md
+++ b/docs/REPOSITORY_STRUCTURE_ANALYSIS.md
@@ -77,7 +77,7 @@ The AILIS repository is a well-structured, proposal-based project for an AI Laye
 | `proposal-lifecycle.yml` | PR (proposals/), daily | Auto-label proposals and track stages | 11 KB |
 | `proposal-stage-transitions.yml` | Issue labels | Handle stage transitions (draft→review→final→decision) | 7.6 KB |
 | `readme-compilation.yml` | Push (main), PR, weekly | Dynamically update README with stats | 9.8 KB |
-| `changelog-automation.yml` | Merged PRs | Extract PR titles/descriptions → changelog | 8.9 KB |
+| `changelog-automation.yml` | Merged PRs, releases, manual | Extract PR titles/descriptions → changelog | 8.9 KB |
 | `yaml-validation.yml` | Workflow file changes | Validate GitHub Actions workflow YAML | 2.2 KB |
 | `validate-config.yml` | Config changes, manual | Validate all configuration files | 3.2 KB |
 | `version-consistency.yml` | Workflow changes, manual | Check version consistency across files | 5.0 KB |


### PR DESCRIPTION
## Summary

Remove the weekly schedule from `changelog-automation.yml` so the changelog workflow no longer opens dead PRs every Sunday.

## Why

The current weekly run creates an automated changelog branch and PR even when that update is not useful for the repo's day-to-day workflow. This has accumulated a long tail of stale open PRs and creates noise instead of signal.

## Changes

- remove the weekly `schedule` trigger from `.github/workflows/changelog-automation.yml`
- update `docs/REPOSITORY_STRUCTURE_ANALYSIS.md` so the documented triggers match the workflow

## What stays

The changelog workflow still runs on:

- merged PR handling
- releases
- manual dispatch
