### PR TITLE
fix: stop weekly README PR churn

### DIFF
--- a/.github/workflows/readme-compilation.yml
+++ b/.github/workflows/readme-compilation.yml
@@ -14,9 +14,6 @@ on:
       - 'docs/readme-parts/**'
       - '.github/readme-template.md'
       - 'proposals/**/*.md'
-  schedule:
-    # Regenerate README weekly on Sundays at 2 AM UTC
-    - cron: '0 2 * * 0'
   workflow_dispatch:
     inputs:
       force_regenerate:

--- a/docs/REPOSITORY_STRUCTURE_ANALYSIS.md
+++ b/docs/REPOSITORY_STRUCTURE_ANALYSIS.md
@@ -76,7 +76,7 @@ The AILIS repository is a well-structured, proposal-based project for an AI Laye
 | `accessibility-check.yml` | PR, push | Check heading hierarchy, alt text, link text | 2.9 KB |
 | `proposal-lifecycle.yml` | PR (proposals/), daily | Auto-label proposals and track stages | 11 KB |
 | `proposal-stage-transitions.yml` | Issue labels | Handle stage transitions (draft→review→final→decision) | 7.6 KB |
-| `readme-compilation.yml` | Push (main), PR, weekly | Dynamically update README with stats | 9.8 KB |
+| `readme-compilation.yml` | Push (main), PR, manual | Dynamically update README with stats | 9.8 KB |
 | `changelog-automation.yml` | Merged PRs, releases, manual | Extract PR titles/descriptions → changelog | 8.9 KB |
 | `yaml-validation.yml` | Workflow file changes | Validate GitHub Actions workflow YAML | 2.2 KB |
 | `validate-config.yml` | Config changes, manual | Validate all configuration files | 3.2 KB |


### PR DESCRIPTION
## Summary

Remove the weekly schedule from `readme-compilation.yml` so the README workflow no longer opens background PRs on protected `main` every Sunday.

## Why

Like the changelog workflow before it, the README compilation workflow can fall back to PR creation when direct pushes to `main` are blocked. Keeping the weekly schedule means it can generate recurring automation noise even when that update is not especially useful.

## Changes

- remove the weekly `schedule` trigger from `.github/workflows/readme-compilation.yml`
- update `docs/REPOSITORY_STRUCTURE_ANALYSIS.md` so the documented triggers match reality

## What stays

The README workflow still runs on:

- pushes affecting README compilation inputs
- pull requests affecting README compilation inputs
- manual dispatch
