### PR TITLE
[codex] add compute market case studies

### DIFF
--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1462,9 +1462,16 @@ body {
 
 .ailis-case-study-lead h2 {
   margin-top: 0.3rem;
+  font-size: clamp(1.55rem, 2.6vw, 2rem);
+  letter-spacing: 0;
+  line-height: 1.12;
+  overflow-wrap: normal;
+  text-wrap: balance;
+  word-break: normal;
 }
 
 .ailis-case-study-lead h2 a {
+  display: inline;
   color: inherit;
   text-decoration: none;
 }
@@ -1478,7 +1485,7 @@ body {
   color: var(--ailis-ink-700);
 }
 
-.ailis-case-study-lead a {
+.ailis-case-study-cta {
   display: inline-flex;
   margin-top: 0.85rem;
   color: var(--ailis-lane-research);
@@ -1522,9 +1529,72 @@ body {
 }
 
 .ailis-case-study-list span {
+  display: block;
   color: var(--ailis-ink-700);
   font-size: 0.8rem;
   line-height: 1.45;
+}
+
+.ailis-case-study-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0 1.8rem;
+}
+
+.ailis-case-study-card {
+  border: 1px solid color-mix(in srgb, var(--ailis-case-study-lane, var(--ailis-lane-research)) 22%, var(--ailis-line));
+  border-radius: var(--ailis-radius-md);
+  background:
+    radial-gradient(circle at 92% 12%, color-mix(in srgb, var(--ailis-case-study-lane-bright, var(--ailis-lane-research-bright)) 13%, transparent), transparent 8rem),
+    linear-gradient(180deg, color-mix(in srgb, var(--ailis-case-study-lane-soft, var(--ailis-lane-research-soft)) 34%, var(--ailis-paper-strong)), var(--ailis-paper-strong));
+  box-shadow: var(--ailis-shadow-soft);
+  padding: 1rem;
+}
+
+.ailis-case-study-card.lane-core {
+  --ailis-case-study-lane: var(--ailis-lane-core);
+  --ailis-case-study-lane-bright: var(--ailis-lane-core-bright);
+  --ailis-case-study-lane-soft: var(--ailis-lane-core-soft);
+}
+
+.ailis-case-study-card.lane-protocol {
+  --ailis-case-study-lane: var(--ailis-lane-protocol);
+  --ailis-case-study-lane-bright: var(--ailis-lane-protocol-bright);
+  --ailis-case-study-lane-soft: var(--ailis-lane-protocol-soft);
+}
+
+.ailis-case-study-card.lane-research {
+  --ailis-case-study-lane: var(--ailis-lane-research);
+  --ailis-case-study-lane-bright: var(--ailis-lane-research-bright);
+  --ailis-case-study-lane-soft: var(--ailis-lane-research-soft);
+}
+
+.ailis-case-study-card h3,
+.ailis-case-study-card p {
+  margin: 0;
+}
+
+.ailis-case-study-card h3 {
+  margin-top: 0.35rem;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.ailis-case-study-card h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.ailis-case-study-card h3 a:hover {
+  color: var(--ailis-case-study-lane, var(--ailis-lane-research));
+}
+
+.ailis-case-study-card p {
+  margin-top: 0.6rem;
+  color: var(--ailis-ink-700);
+  font-size: 0.84rem;
+  line-height: 1.55;
 }
 
 .ailis-dollhouse-project {
@@ -1798,6 +1868,7 @@ button:focus-visible,
 
   .ailis-card-grid,
   .ailis-case-study-feature,
+  .ailis-case-study-card-grid,
   .ailis-dollhouse-project-grid,
   .ailis-related-grid,
   .ailis-layer-atlas-grid,

--- a/docs/layers/l12-routing-planning-policy.md
+++ b/docs/layers/l12-routing-planning-policy.md
@@ -31,7 +31,7 @@ L12 sits above individual model and tool capabilities. It may choose between pro
 | [LangGraph](https://langchain-ai.github.io/langgraph/) | Graph-based orchestration for controllable agent workflows. | L12 planning, L14 memory |
 | [Microsoft AutoGen](https://microsoft.github.io/autogen/) | Multi-agent framework for planning and collaboration patterns. | L12 planning, L16 applications |
 | [CrewAI](https://docs.crewai.com/) | Agent orchestration framework centered on roles, tasks, and crews. | L12 planning, L16 applications |
-| [Open Policy Agent](https://www.openpolicyagent.org/docs/latest/) | General policy engine that can inform AI routing and authorization decisions. | L12 policy, L15 governance |
+| [Open Policy Agent](https://www.openpolicyagent.org/docs) | General policy engine that can inform AI routing and authorization decisions. | L12 policy, L15 governance |
 | [MCP-AQL spec](../studies/dollhouse-public-stack-mapping.md#mcp-aql-spec) | Public protocol work that introduces routing cues, semantic operation choices, and execution policy questions above basic tool invocation. | L12 routing, L10 invocation |
 | [DollhouseMCP approvals and workflow policy](../studies/dollhouse-public-stack-mapping.md#dollhousemcp) | Human review paths and execution constraints that make policy visible in the product rather than hiding it in infrastructure. | L12 policy, L15 governance |
 

--- a/docs/session-notes/session-notes-2026-05-07-compute-market-ensemble.md
+++ b/docs/session-notes/session-notes-2026-05-07-compute-market-ensemble.md
@@ -1,0 +1,95 @@
+# Session Notes: Compute Market Ensemble and AILIS Drafts
+
+**Date:** 2026-05-07
+
+## Session Overview
+
+Built a DollhouseMCP analyst ensemble for studying AI compute as a layered
+financial and technology market, then used the research frame to draft AILIS
+study material around compute financialization, basis risk, contracts, and
+benchmarks.
+
+## Goals
+
+- Create a reusable DollhouseMCP ensemble that can independently research,
+  model, and write about compute markets.
+- Research current industry discussion rather than relying on prior model
+  knowledge.
+- Draft AILIS-facing analysis papers that explain why a layered model is useful
+  for compute-market interpretation.
+- Fix the Case Studies index feature-card layout so project names and
+  descriptions render as separate lines and the featured title wraps cleanly.
+
+## DollhouseMCP Elements Created
+
+- `layered-compute-market-strategist` persona
+- `ailis-compute-layer-mapping` skill
+- `compute-basis-risk-modeling` skill
+- `compute-market-structure-research` skill
+- `compute-market-writing` skill
+- `ailis-compute-market-brief` template
+- `compute-market-research-agent` agent
+- `compute-market-research-ledger` memory
+- `layered-compute-market-analyst` ensemble
+
+The ensemble was validated and activated. The research ledger was seeded with
+the initial source set and working hypothesis.
+
+## AILIS Drafts Created
+
+- `studies/compute-as-layered-market.md`
+- `studies/compute-basis-risk-model.md`
+- `studies/compute-market-structure-checklist.md`
+
+`studies/index.md` was updated to link the new research drafts.
+
+## Website Fixes
+
+- Reworked the Case Studies index feature area from mixed Markdown-in-HTML to
+  explicit HTML, making the intended list and card classes stable.
+- Scoped the featured card call-to-action styling to `.ailis-case-study-cta`
+  so it no longer affects the title link.
+- Added a three-card Compute Market Research section for the new drafts.
+
+## Research Sources Used
+
+Current-source research covered:
+
+- Larry Fink's May 2026 compute-futures remarks reported by Bloomberg Law.
+- Silicon Data GPU forward curve and methodology discussion.
+- Forward Compute's compute insurance, swaps, forwards, and index framing.
+- IEA 2026 and DOE/LBNL data center electricity demand material.
+- Micron and Samsung 2026 memory/HBM statements.
+- NVIDIA and Emerald AI's power-flexible AI factory announcement.
+- Microsoft Sovereign Cloud and EU AI Factories material.
+- CFTC and IOSCO market-structure and benchmark-governance references.
+- Berkeley's Enron bandwidth trading analysis as a cautionary analogy.
+
+## Key Decisions
+
+- Frame compute as a quality-adjusted, layered capacity bundle rather than a
+  single commodity.
+- Treat AILIS as an exploratory vocabulary for surfacing basis risk, not as a
+  prescriptive market standard.
+- Draft research material under `studies/` as reviewable papers rather than
+  accepted proposals.
+
+## Validation
+
+- Dollhouse element validation passed for the agent, ensemble, memory, persona,
+  skills, and template, with only non-blocking usability suggestions.
+- `mkdocs build` passed using a temporary Python 3.11 virtual environment.
+- Browser checks were run against the local MkDocs server for the Case Studies
+  index at desktop and mobile widths.
+- `mkdocs build --strict` initially failed because new uncommitted pages had no
+  git revision history yet; this is expected for newly added files under the
+  git revision date plugin.
+- `git diff --check` and trailing-whitespace checks passed.
+
+## Next Steps
+
+- Review the three drafts for tone, claims, and publication readiness.
+- Consider turning the contract checklist into a reference artifact if the
+  community finds it useful.
+- Consider a LinkedIn post that introduces the compute-as-layers framing before
+  linking to the AILIS drafts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -204,9 +204,8 @@ markdown_extensions:
   - pymdownx.snippets:
       auto_append:
         - includes/abbreviations.md
-  # Keeps nested fences working. No mermaid fences exist today; add the mermaid
-  # custom fence here if diagrams are introduced later.
-  - pymdownx.superfences
+  # Render top-level fenced code blocks.
+  - fenced_code
 
 # Extra CSS and JavaScript
 extra_css:

--- a/studies/compute-as-layered-market.md
+++ b/studies/compute-as-layered-market.md
@@ -1,0 +1,133 @@
+---
+title: Compute as a Layered Market
+description: Exploratory AILIS analysis of compute financialization, infrastructure scarcity, and layer-aware basis risk.
+---
+
+<!-- markdownlint-disable MD013 -->
+
+# Compute as a Layered Market
+
+This note is a draft research paper for discussion. It is not financial advice, a market forecast, or a claim that AILIS has solved compute-market design. The narrower claim is that AILIS might help explain why "compute" is becoming financially interesting precisely because it is not one simple commodity.
+
+## Trigger
+
+On May 5, 2026, Bloomberg reported that BlackRock CEO Larry Fink told the Milken Institute Global Conference that demand for computing power could support a future market for compute futures, while also pointing to shortages in compute capacity, chips, and memory. That comment landed in a broader conversation that was already forming around GPU forward curves, compute swaps, AI infrastructure finance, data center power, HBM supply, and the limits of treating a GPU-hour as if it were as simple as a barrel of oil.
+
+The social discussion around the quote surfaced the right tension. Compute can look commodity-like from far away, but in practice it is assembled from layers: power, cooling, chips, memory, interconnect, runtime software, model architecture, quantization, routing, policy, jurisdiction, and workload economics. A change at one layer might reprice compute in ways that are not obvious to people watching only the headline layer.
+
+## Thesis
+
+Compute might become tradable only where enough of its layers can be standardized, measured, and settled. The remaining non-standardized layers become the source of basis risk, contract disputes, operational exposure, and perhaps arbitrage.
+
+AILIS provides a vocabulary for that decomposition. It does not tell us whether a compute futures market should exist. It does help ask better questions:
+
+- Which layer is scarce?
+- Which layer is being priced?
+- Which layer is being ignored?
+- What compute does the buyer actually need?
+- What compute does the hedge, index, or contract actually deliver?
+
+## What Is Current
+
+| Signal | Source | Why it matters |
+| --- | --- | --- |
+| Compute futures entered mainstream finance discourse in May 2026. | [Bloomberg Law, May 5, 2026](https://news.bloomberglaw.com/private-equity/larry-fink-predicts-birth-of-futures-market-for-computing-power) | A top asset manager is publicly framing compute as a possible tradable exposure. |
+| GPU forward curves are now being marketed as a pricing primitive. | [Silicon Data GPU Forward Curve](https://www.silicondata.com/products/forward-curve) and [May 1, 2026 methodology blog](https://www.silicondata.com/blog/the-gpu-forward-curve-pricing-the-curve-not-just-the-spot) | Market infrastructure is appearing before exchange-traded liquidity. |
+| Compute-specific risk-transfer firms are positioning around swaps, forwards, insurance, and indices. | [Forward Compute](https://www.forwardcompute.ai/) | Compute finance may begin with OTC risk transfer and insurance before public futures. |
+| Data center electricity demand remains a binding infrastructure concern. | [IEA Key Questions on Energy and AI](https://www.iea.org/reports/key-questions-on-energy-and-ai/executive-summary), [DOE/LBNL summary](https://www.energy.gov/articles/doe-releases-new-report-evaluating-increase-electricity-demand-data-centers) | L0 power and siting can constrain L1 compute availability. |
+| Memory is being reframed as a strategic AI input. | [Micron fiscal Q2 2026 results](https://investors.micron.com/news-releases/news-release-details/micron-technology-inc-reports-results-second-quarter-fiscal-2026), [Samsung Q1 2026 results](https://news.samsung.com/global/samsung-electronics-announces-first-quarter-2026-results) | A GPU contract may not hedge HBM, DRAM, or KV-cache pressure. |
+| Software and numeric efficiency can change effective capacity without adding physical GPUs. | [vLLM PagedAttention paper](https://arxiv.org/abs/2309.06180), [AWQ paper](https://arxiv.org/abs/2306.00978), [NVIDIA Blackwell inference update](https://developer.nvidia.com/blog/delivering-massive-performance-leaps-for-mixture-of-experts-inference-on-nvidia-blackwell/) | L3/L4 changes can reduce or increase demand for L0/L1 capacity. |
+| Sovereign and disconnected AI infrastructure is becoming a product category. | [Microsoft Sovereign Cloud, Feb. 24, 2026](https://blogs.microsoft.com/blog/2026/02/24/microsoft-sovereign-cloud-adds-governance-productivity-and-support-for-large-ai-models-securely-running-even-when-completely-disconnected/), [EU AI Factories](https://digital-strategy.ec.europa.eu/en/policies/ai-factories) | Some compute cannot freely substitute into cloud capacity markets. |
+
+## Layer Map
+
+| AILIS area | Compute-market interpretation | Example market question |
+| --- | --- | --- |
+| L0 Facilities and Power | Power, land, cooling, interconnection, substations, water, carbon, bridge power. | If a grid queue slips, which capacity contracts become late or more expensive? |
+| L1 Compute Fabric | GPU SKU, HBM, VRAM, interconnect, rack topology, spare parts, fleet age. | Is an H100 index a useful hedge for B200, GB200, MI300X, or ASIC exposure? |
+| L2 System Runtime | CUDA, ROCm, drivers, firmware, orchestration, virtualization. | Can the buyer actually run the workload on the contracted fleet? |
+| L3 Graph and Compilation | Kernel quality, compiler support, serving engine, graph optimization. | Does a software update change effective capacity before any new hardware arrives? |
+| L4 Numeric and Quantization | FP8, FP4, AWQ, sparsity, distillation, precision/accuracy tradeoffs. | Does an efficiency gain reduce demand, or unlock enough use cases to increase total demand? |
+| L5-L9 Data and Context | Data location, tokenization, context windows, retrieval, cacheability, data rights. | Is the bottleneck compute, or the right to move and use data near compute? |
+| L10-L14 Orchestration and Flow | Routing, scheduling, transport semantics, identity, session state, memory. | Can workloads be moved to cheaper capacity without breaking latency or state assumptions? |
+| L15 Governance and Schema | Benchmark definitions, auditability, safety, compliance, sovereignty, contract schema. | Can the market settle on a unit that is auditable and hard to manipulate? |
+| L16 Domain Logic | Revenue per token, training objective, inference SLA, business workflow. | Does a cheaper GPU-hour lower cost per business outcome? |
+
+## Why the Mental Model Breaks
+
+A commodity mental model works best when the unit is standardized enough that one unit can replace another. Compute is often quoted that way, but production AI rarely consumes abstract compute. It consumes specific capacity under specific constraints.
+
+Several examples show the problem:
+
+- A power-market shock enters at L0, but it may show up as longer delivery lead times for racks, higher colocation costs, or more demand for flexible-load contracts.
+- An HBM shortage enters at L1, but it may affect model size, context length, batch economics, and the relative value of quantization.
+- A serving-engine improvement enters at L3, but it can change the effective supply of inference capacity on the same installed fleet.
+- A quantization breakthrough enters at L4, but it may reduce raw compute demand for some workloads while making new edge or on-device workloads feasible.
+- A sovereignty requirement enters at L15, but it can make low-cost public-cloud capacity non-substitutable for regulated buyers.
+
+This is where the arbitrage intuition becomes interesting. Market participants might overreact to the headline layer and underreact to the layer that actually binds the workload.
+
+## Basis Risk
+
+The early compute market seems likely to create multiple forms of basis risk:
+
+| Basis type | Mismatch |
+| --- | --- |
+| SKU basis | Index tracks one accelerator while exposure depends on another. |
+| Topology basis | Index prices single GPU-hours while workload needs tightly coupled racks. |
+| Memory basis | GPU rental price is hedged while HBM, DRAM, or KV-cache capacity drives real constraints. |
+| Power basis | Compute contract ignores regional power, interconnection, or curtailment risk. |
+| Region basis | Global capacity cannot substitute for latency-bound or sovereign capacity. |
+| Duration basis | Spot or monthly price does not match a multi-year product roadmap or financing term. |
+| Reliability basis | SLA credits do not match the buyer's actual business interruption loss. |
+| Workload basis | Training capacity and inference capacity have different economic drivers. |
+| Policy basis | Tradable cloud compute cannot replace on-prem, disconnected, classified, or regulated environments. |
+
+## What AILIS Might Add
+
+AILIS could be useful here in four ways:
+
+1. It can name where scarcity enters the stack.
+2. It can identify which attributes a contract or benchmark includes.
+3. It can show where a hedge fails to match the real workload.
+4. It can help non-financial engineers and non-technical finance teams discuss the same exposure without flattening it into "more GPUs."
+
+The fourth point might be the most practical. The compute market is becoming a meeting point for infrastructure finance, energy markets, semiconductor supply chains, cloud procurement, AI engineering, and governance. A layered map gives those communities a shared surface for disagreement.
+
+## Counterarguments
+
+There are serious reasons to be cautious.
+
+First, the Enron bandwidth analogy is not superficial. A Berkeley working paper on Enron's bandwidth trading effort argued that bandwidth needed standardized contracts, delivery mechanisms, market cooperation, and neutral oversight. It also documented why technical non-fungibility, provisioning complexity, and industry resistance made the market hard to launch. Compute markets may face similar issues, even if cloud APIs, telemetry, and mature infrastructure finance make the environment different.
+
+Second, efficiency gains can cut both ways. vLLM, AWQ, and vendor software optimizations can increase effective capacity. That might reduce scarcity for some workloads. It might also expand total demand by making more AI products economical.
+
+Third, a forward curve is not the same thing as a liquid futures market. It may support budgeting, underwriting, OTC swaps, insurance, or internal transfer pricing long before it supports cleared exchange trading.
+
+Fourth, benchmark governance matters. IOSCO's financial benchmark principles emphasize governance, benchmark quality, methodology quality, and accountability. CFTC rules for futures and swaps emphasize contracts not readily susceptible to manipulation, position accountability, market integrity, and surveillance. A compute index would need to earn trust on those dimensions.
+
+## Open Questions
+
+- What is the smallest useful standard compute unit: GPU-hour, rack-hour, token-throughput-hour, power-backed rack, or workload-specific capacity?
+- Should financial settlement begin with narrow GPU rental indices, or with broader quality-adjusted capacity baskets?
+- How much of the market will remain bilateral because of region, tenancy, sovereignty, or custom topology?
+- Could benchmark administrators publish layer coverage alongside price methodology?
+- Would a compute index need separate curves for training, inference, sovereign compute, and interruptible capacity?
+- Where could AILIS become a checklist for compute contracts rather than just a conceptual model?
+
+## Sources
+
+- Bloomberg Law, [Larry Fink Predicts Birth of Futures Market for Computing Power](https://news.bloomberglaw.com/private-equity/larry-fink-predicts-birth-of-futures-market-for-computing-power), May 5, 2026.
+- Silicon Data, [GPU Forward Curve](https://www.silicondata.com/products/forward-curve), accessed May 7, 2026.
+- Silicon Data, [The GPU Forward Curve: Pricing the Curve, Not Just the Spot](https://www.silicondata.com/blog/the-gpu-forward-curve-pricing-the-curve-not-just-the-spot), May 1, 2026.
+- Forward Compute, [Insurance and financial derivatives for compute](https://www.forwardcompute.ai/), accessed May 7, 2026.
+- IEA, [Key Questions on Energy and AI](https://www.iea.org/reports/key-questions-on-energy-and-ai/executive-summary), accessed May 7, 2026.
+- U.S. Department of Energy, [DOE Releases New Report Evaluating Increase in Electricity Demand from Data Centers](https://www.energy.gov/articles/doe-releases-new-report-evaluating-increase-electricity-demand-data-centers), Dec. 20, 2024.
+- Micron, [Fiscal Q2 2026 results](https://investors.micron.com/news-releases/news-release-details/micron-technology-inc-reports-results-second-quarter-fiscal-2026), Mar. 18, 2026.
+- Samsung, [First Quarter 2026 Results](https://news.samsung.com/global/samsung-electronics-announces-first-quarter-2026-results), Apr. 30, 2026.
+- NVIDIA, [Flexible AI Factories as Grid Assets](https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-and-Emerald-AI-Join-Leading-Energy-Companies-to-Pioneer-Flexible-AI-Factories-as-Grid-Assets/default.aspx), Mar. 23, 2026.
+- Microsoft, [Sovereign Cloud adds disconnected large-model support](https://blogs.microsoft.com/blog/2026/02/24/microsoft-sovereign-cloud-adds-governance-productivity-and-support-for-large-ai-models-securely-running-even-when-completely-disconnected/), Feb. 24, 2026.
+- European Commission, [AI Factories](https://digital-strategy.ec.europa.eu/en/policies/ai-factories), accessed May 7, 2026.
+- Andrew Schwartz, [Enron's Missed Opportunity](https://brie.berkeley.edu/sites/default/files/wp152.pdf), Berkeley Roundtable on the International Economy, 2002/2003.
+- Financial Stability Board, [IOSCO Principles for Financial Benchmarks](https://www.fsb.org/2013/07/cos_130717/), July 17, 2013.
+- CFTC, [Economic Requirements](https://www.cftc.gov/IndustryOversight/ContractsProducts/EconomicRequirements/index.htm), accessed May 7, 2026.

--- a/studies/compute-basis-risk-model.md
+++ b/studies/compute-basis-risk-model.md
@@ -1,0 +1,162 @@
+---
+title: A Layered Basis Risk Model for Compute Capacity
+description: Draft analytical model for quality-adjusted compute exposure using AILIS layers.
+---
+
+<!-- markdownlint-disable MD013 -->
+
+# A Layered Basis Risk Model for Compute Capacity
+
+This draft proposes a modeling frame for compute exposure. It is intentionally simple enough to be criticized. The goal is not to define the correct compute unit, but to show how a layered model might expose mismatches that a raw GPU-hour view can hide.
+
+## Working Definition
+
+Compute basis risk is the mismatch between the compute exposure a buyer, lender, insurer, or operator actually has and the compute exposure represented by a contract, index, hedge, budget, or headline.
+
+A buyer might hedge H100 rental rates and still remain exposed to HBM supply, power delays, region-specific latency, software compatibility, or a model-efficiency shock. The hedge might be economically useful, but it is not the whole exposure.
+
+## Quality-Adjusted Compute Unit
+
+A possible starting abstraction:
+
+```text
+QACU =
+  raw_gpu_hours
+  * utilization_factor
+  * performance_factor
+  * availability_factor
+  * locality_factor
+  * policy_factor
+  * settlement_factor
+```
+
+Where:
+
+| Factor | AILIS anchors | What it captures |
+| --- | --- | --- |
+| `raw_gpu_hours` | L1 | Quantity of accelerator time before adjustment. |
+| `utilization_factor` | L2-L3, L10-L12 | Scheduler efficiency, batch shape, prefill/decode split, orchestration. |
+| `performance_factor` | L1-L4 | SKU, memory, interconnect, compiler, kernels, precision, quantization. |
+| `availability_factor` | L0-L2, L13 | Uptime, interruptibility, maintenance windows, delivery confidence. |
+| `locality_factor` | L0, L9, L13-L15 | Region, data gravity, latency, data movement, sovereignty. |
+| `policy_factor` | L15 | Compliance, tenancy, auditability, safety and governance constraints. |
+| `settlement_factor` | L11, L15 | Index fit, measurement quality, delivery verification, counterparty credit. |
+
+This is not a pricing model by itself. It is a scaffold for asking which adjustments matter for a given exposure.
+
+## Layer Shock Matrix
+
+| Shock | Entry layer | Possible market effect | Who might misread it |
+| --- | --- | --- | --- |
+| Grid interconnection delay | L0 | Reserved capacity slips, bridge power cost rises, flexible-load value increases. | Traders watching only GPU spot rates. |
+| HBM shortage or allocation change | L1 | High-memory workloads reprice; long-context inference becomes capacity-constrained. | Buyers hedged with generic GPU-hour curves. |
+| New GPU generation ramps | L1 | Older fleets may fall in price, unless software support or availability keeps them valuable. | Buyers assuming all new-generation capacity substitutes one-for-one. |
+| TensorRT/vLLM-style serving gain | L3 | Effective inference capacity rises on installed hardware. | Infrastructure investors modeling only physical supply. |
+| Quantization breakthrough | L4 | Some workloads shift to cheaper devices; others expand demand because costs fall. | Commentators assuming efficiency always lowers aggregate demand. |
+| Larger context windows become standard | L8-L9 | KV-cache and memory pressure can dominate raw FLOPs. | Contract designers ignoring memory and storage layers. |
+| Sovereign/disconnected requirement | L15 | Public-cloud capacity becomes non-substitutable for some regulated workloads. | Index users applying a global cloud price to local obligations. |
+| Benchmark methodology change | L11/L15 | Settlement value changes without any physical supply change. | Risk managers treating index governance as a back-office detail. |
+
+## Scenario Sketches
+
+### Scenario 1: Power-Constrained Contango
+
+If data center projects are delayed by grid interconnection queues, short-term delivered compute may become more valuable even if chip supply improves. The forward curve could steepen for regions where power and substations are binding. The arbitrage question is not "more GPUs or fewer GPUs?" but "which regions have deliverable powered racks?"
+
+Relevant evidence: IEA projects data center electricity consumption roughly doubling from 485 TWh in 2025 to 950 TWh in 2030, while DOE/LBNL estimated U.S. data centers could rise from 4.4% of U.S. electricity in 2023 to 6.7-12% by 2028.
+
+### Scenario 2: Memory-Constrained Compute
+
+If HBM and high-value server memory remain constrained, raw GPU capacity could be a misleading proxy. A model with larger context or memory bandwidth needs may price against HBM availability, not just accelerator count.
+
+Relevant evidence: Micron described memory as a strategic asset in its fiscal Q2 2026 results, and Samsung's Q1 2026 update pointed to continued AI infrastructure demand, HBM4 sales, HBM4E sampling plans, and strong server-memory demand.
+
+### Scenario 3: Efficiency Shock
+
+Software and numeric improvements can increase effective compute supply. vLLM reported 2-4x throughput improvements at similar latency in its evaluated serving workloads. AWQ reported strong 4-bit deployment performance and more than 3x TinyChat speedup versus Hugging Face FP16 on tested desktop and mobile GPUs. NVIDIA reported up to 2.8x per-GPU Blackwell throughput gains over three months from TensorRT-LLM optimizations in early 2026.
+
+The market question is ambiguous. Efficiency could reduce demand for raw GPU-hours in a fixed workload. It could also increase demand by making AI features cheap enough to embed everywhere.
+
+### Scenario 4: Sovereign Non-Substitution
+
+If a buyer needs disconnected, on-prem, or sovereign infrastructure, a global public-cloud GPU index might be a poor hedge. The contractual unit might need to include operational boundary, control plane location, identity/data residency, and local hardware rights.
+
+Relevant evidence: Microsoft's February 2026 Sovereign Cloud announcement emphasized fully disconnected local operations and large-model support within customer-controlled boundaries. The EU AI Factories initiative similarly ties compute capacity to regional industrial, research, public-sector, and sovereignty goals.
+
+## Data Schema For Analysis
+
+The following schema could support an internal research notebook, spreadsheet, or agent memory:
+
+```yaml
+compute_exposure:
+  workload:
+    type: training | inference | evaluation | batch | edge | sovereign
+    model_family: string
+    sequence_profile: input_tokens/output_tokens/context_window
+    latency_requirement: p50/p95/p99
+  capacity:
+    accelerator: sku
+    memory_gb: number
+    interconnect: topology
+    region: string
+    tenancy: shared | dedicated | on_prem | sovereign
+    duration: spot | monthly | reserved | multi_year
+  layer_constraints:
+    l0_power: grid | colocated | bridge | flexible
+    l1_memory: hbm | dram | kv_cache | storage
+    l2_runtime: cuda | rocm | custom
+    l3_engine: vllm | tensorrt_llm | other
+    l4_precision: fp16 | fp8 | fp4 | int4 | mixed
+    l15_policy: public_cloud | regulated | disconnected | classified
+  hedge_or_index:
+    reference_name: string
+    settlement_type: financial | physical | parametric | hybrid
+    methodology_url: string
+    coverage_layers: [L0, L1, L2, L3, L4, L15]
+  residual_basis_risks:
+    - type: sku_basis
+      severity: low | medium | high
+      note: string
+```
+
+## Layer-Aware Arbitrage Questions
+
+The word arbitrage should be used carefully. Some opportunities will be true arbitrage; many will be information advantages, procurement advantages, operational flexibility, or better hedging. AILIS can still help identify where the gap lives.
+
+| If the market reacts to... | But the binding layer is... | Possible analytical edge |
+| --- | --- | --- |
+| GPU spot prices | L0 power | Model power-backed capacity spreads by region. |
+| H100 rental curve | L1 memory/topology | Compare memory-rich versus compute-rich capacity. |
+| Chip shipments | L2-L3 software readiness | Track usable capacity, not shipped silicon. |
+| Quantization news | L16 workload economics | Separate workloads where quality loss is acceptable from those where it is not. |
+| Sovereign AI announcements | L15 governance | Estimate non-substitutable local demand versus global cloud oversupply. |
+| Forward-curve publication | L11/L15 benchmark governance | Analyze methodology, data sufficiency, and manipulation risk before trusting settlement. |
+
+## How To Use The Model
+
+1. Start with the real exposure, not the available hedge.
+2. Map the exposure to layers.
+3. Map the index or contract to layers.
+4. Compare included and excluded attributes.
+5. Stress the excluded attributes.
+6. Describe the residual basis risk in plain language.
+
+## Open Questions
+
+- Should AILIS define a "Layer Coverage Statement" for compute benchmarks?
+- Could compute contracts expose both a raw unit and a quality-adjusted unit?
+- How should model-efficiency improvements be represented in market data?
+- Should power-flexible AI factories receive a different capacity category from static loads?
+- What empirical data would make QACU less speculative?
+
+## Sources
+
+- IEA, [Key Questions on Energy and AI](https://www.iea.org/reports/key-questions-on-energy-and-ai/executive-summary), accessed May 7, 2026.
+- U.S. Department of Energy, [DOE Releases New Report Evaluating Increase in Electricity Demand from Data Centers](https://www.energy.gov/articles/doe-releases-new-report-evaluating-increase-electricity-demand-data-centers), Dec. 20, 2024.
+- Micron, [Fiscal Q2 2026 results](https://investors.micron.com/news-releases/news-release-details/micron-technology-inc-reports-results-second-quarter-fiscal-2026), Mar. 18, 2026.
+- Samsung, [First Quarter 2026 Results](https://news.samsung.com/global/samsung-electronics-announces-first-quarter-2026-results), Apr. 30, 2026.
+- vLLM, [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180), 2023.
+- AWQ, [Activation-aware Weight Quantization for LLM Compression and Acceleration](https://arxiv.org/abs/2306.00978), 2023.
+- NVIDIA, [Delivering Massive Performance Leaps for Mixture of Experts Inference on NVIDIA Blackwell](https://developer.nvidia.com/blog/delivering-massive-performance-leaps-for-mixture-of-experts-inference-on-nvidia-blackwell/), Jan. 8, 2026.
+- Microsoft, [Sovereign Cloud adds disconnected large-model support](https://blogs.microsoft.com/blog/2026/02/24/microsoft-sovereign-cloud-adds-governance-productivity-and-support-for-large-ai-models-securely-running-even-when-completely-disconnected/), Feb. 24, 2026.
+- European Commission, [AI Factories](https://digital-strategy.ec.europa.eu/en/policies/ai-factories), accessed May 7, 2026.

--- a/studies/compute-basis-risk-model.md
+++ b/studies/compute-basis-risk-model.md
@@ -83,40 +83,183 @@ If a buyer needs disconnected, on-prem, or sovereign infrastructure, a global pu
 
 Relevant evidence: Microsoft's February 2026 Sovereign Cloud announcement emphasized fully disconnected local operations and large-model support within customer-controlled boundaries. The EU AI Factories initiative similarly ties compute capacity to regional industrial, research, public-sector, and sovereignty goals.
 
-## Data Schema For Analysis
+## Layered Exposure Record Schema
 
-The following schema could support an internal research notebook, spreadsheet, or agent memory:
+The following schema could support an internal research notebook, spreadsheet, or agent memory. It uses a
+JSON-Schema-style shape so the fields can be validated rather than read as shorthand.
 
 ```yaml
-compute_exposure:
+title: LayeredComputeExposure
+type: object
+required:
+  - workload
+  - capacity
+  - layer_constraints
+  - hedge_or_index
+  - residual_basis_risks
+properties:
   workload:
-    type: training | inference | evaluation | batch | edge | sovereign
-    model_family: string
-    sequence_profile: input_tokens/output_tokens/context_window
-    latency_requirement: p50/p95/p99
+    type: object
+    required:
+      - exposure_type
+      - model_family
+      - sequence_profile
+      - latency_requirement
+    properties:
+      exposure_type:
+        type: string
+        enum:
+          - training
+          - inference
+          - evaluation
+          - batch
+          - edge
+          - sovereign
+      model_family:
+        type: string
+      sequence_profile:
+        type: object
+        properties:
+          input_tokens:
+            type: integer
+          output_tokens:
+            type: integer
+          context_window:
+            type: integer
+      latency_requirement:
+        type: object
+        properties:
+          p50_ms:
+            type: integer
+          p95_ms:
+            type: integer
+          p99_ms:
+            type: integer
+
   capacity:
-    accelerator: sku
-    memory_gb: number
-    interconnect: topology
-    region: string
-    tenancy: shared | dedicated | on_prem | sovereign
-    duration: spot | monthly | reserved | multi_year
+    type: object
+    required:
+      - accelerator_sku
+      - memory_gb
+      - interconnect
+      - region
+      - tenancy
+      - duration
+    properties:
+      accelerator_sku:
+        type: string
+      memory_gb:
+        type: number
+      interconnect:
+        type: string
+      region:
+        type: string
+      tenancy:
+        type: string
+        enum:
+          - shared
+          - dedicated
+          - on_prem
+          - sovereign
+      duration:
+        type: string
+        enum:
+          - spot
+          - monthly
+          - reserved
+          - multi_year
+
   layer_constraints:
-    l0_power: grid | colocated | bridge | flexible
-    l1_memory: hbm | dram | kv_cache | storage
-    l2_runtime: cuda | rocm | custom
-    l3_engine: vllm | tensorrt_llm | other
-    l4_precision: fp16 | fp8 | fp4 | int4 | mixed
-    l15_policy: public_cloud | regulated | disconnected | classified
+    type: object
+    properties:
+      l0_power:
+        type: string
+        enum:
+          - grid
+          - colocated
+          - bridge
+          - flexible
+      l1_memory:
+        type: string
+        enum:
+          - hbm
+          - dram
+          - kv_cache
+          - storage
+      l2_runtime:
+        type: string
+        enum:
+          - cuda
+          - rocm
+          - custom
+      l3_engine:
+        type: string
+      l4_precision:
+        type: string
+        enum:
+          - fp16
+          - fp8
+          - fp4
+          - int4
+          - mixed
+      l15_policy:
+        type: string
+        enum:
+          - public_cloud
+          - regulated
+          - disconnected
+          - classified
+
   hedge_or_index:
-    reference_name: string
-    settlement_type: financial | physical | parametric | hybrid
-    methodology_url: string
-    coverage_layers: [L0, L1, L2, L3, L4, L15]
+    type: object
+    required:
+      - reference_name
+      - settlement_type
+      - methodology_url
+      - coverage_layers
+    properties:
+      reference_name:
+        type: string
+      settlement_type:
+        type: string
+        enum:
+          - financial
+          - physical
+          - parametric
+          - hybrid
+      methodology_url:
+        type: string
+      coverage_layers:
+        type: array
+        items:
+          type: string
+          enum:
+            - L0
+            - L1
+            - L2
+            - L3
+            - L4
+            - L15
+
   residual_basis_risks:
-    - type: sku_basis
-      severity: low | medium | high
-      note: string
+    type: array
+    items:
+      type: object
+      required:
+        - risk_type
+        - severity
+        - note
+      properties:
+        risk_type:
+          type: string
+        severity:
+          type: string
+          enum:
+            - low
+            - medium
+            - high
+        note:
+          type: string
 ```
 
 ## Layer-Aware Arbitrage Questions

--- a/studies/compute-market-structure-checklist.md
+++ b/studies/compute-market-structure-checklist.md
@@ -1,0 +1,127 @@
+---
+title: Compute Capacity Contract and Benchmark Checklist
+description: Draft checklist for evaluating compute-market contracts, benchmarks, and risk-transfer instruments through AILIS.
+---
+
+<!-- markdownlint-disable MD013 -->
+
+# Compute Capacity Contract and Benchmark Checklist
+
+This checklist is a draft. It is meant to help AILIS readers evaluate compute-capacity contracts, forward curves, swaps, insurance products, and benchmark claims without flattening compute into a single unit.
+
+The premise is simple: before compute can become commodity-like, market participants need to know what is being delivered, measured, substituted, insured, and settled.
+
+## Why A Checklist Is Needed
+
+The Enron bandwidth analogy is useful because it is uncomfortable. Bandwidth had real supply, real demand expectations, and real financial interest. It also had standardization problems: delivery locations, quality of service, provisioning, billing, industry cooperation, and contract terms. A Berkeley working paper on Enron's bandwidth effort emphasized that spot and forward markets depended on delivery confidence and a master services agreement with shared terms.
+
+Compute may be different in important ways. Cloud APIs, accelerator telemetry, data center finance, and benchmark infrastructure are more mature than bandwidth trading was in 2000. But the contract problem still rhymes. A "GPU-hour" might not specify enough to support institutional settlement.
+
+## Contract Checklist
+
+| Area | Questions |
+| --- | --- |
+| Deliverable unit | Is the unit GPU-hour, rack-hour, token throughput, power-backed rack, reserved instance, capacity block, or workload outcome? |
+| Hardware | Which accelerator SKU, memory size, HBM generation, topology, CPU pairing, storage, and network fabric are included? |
+| Performance | Is performance measured by FLOPs, tokens/sec, latency percentiles, job completion, benchmark score, or workload-specific output? |
+| Duration | Is the term spot, interruptible, monthly, forward-starting, take-or-pay, multi-year, or perpetual hardware ownership? |
+| Location | What region, availability zone, data center, grid node, or sovereign boundary applies? |
+| Power and cooling | Is the contract exposed to power price, curtailment, interconnection delay, peak events, PUE, cooling type, or water constraints? |
+| Software stack | Are drivers, runtime, compiler, serving engine, container image, firmware, and orchestration commitments specified? |
+| Tenancy and security | Is capacity shared, dedicated, isolated, air-gapped, on-prem, sovereign, or classified? |
+| Data movement | Who pays for ingress, egress, storage, retrieval, cache, replication, and data-locality constraints? |
+| Governance | Which audit, safety, privacy, data residency, model governance, and regulatory obligations attach? |
+| Reliability | What uptime, maintenance, interruption, restart, checkpointing, and service-credit terms apply? |
+| Substitution | Can the provider substitute SKU, region, topology, software stack, or cloud vendor? What adjustment follows? |
+| Measurement | Who measures delivery, how often, using what telemetry, and with what dispute process? |
+| Settlement | Is settlement physical, financial, parametric, or hybrid? What happens if delivery and index price diverge? |
+| Index linkage | Which benchmark or curve is referenced? What is its methodology, data source, governance, and revision process? |
+| Credit and collateral | How are vendor default, buyer non-payment, GPU residual value, lender rights, and collateral depreciation handled? |
+| Outage and loss | Do remedies match actual business loss, or only a small service credit? Is insurance available? |
+| Change control | How are methodology, hardware, software, precision, and policy changes versioned and noticed? |
+
+## Benchmark Checklist
+
+Financial benchmark governance becomes central if compute contracts settle against indices. IOSCO's principles point to governance, benchmark quality, methodology quality, and accountability. CFTC material on contract listings emphasizes contracts not readily susceptible to manipulation and position accountability where needed.
+
+For a compute benchmark, ask:
+
+- Is the benchmark based on real transactions, firm bids/offers, posted prices, surveys, or modeled values?
+- Are the data sources broad enough to represent the claimed market?
+- Which providers, regions, SKUs, terms, and tenancy types are included or excluded?
+- How are outliers, stale prices, failed transactions, and private discounts handled?
+- Is the methodology public, versioned, and auditable?
+- Who governs conflicts of interest?
+- Can market participants manipulate the benchmark by posting non-executable offers?
+- Is the benchmark useful for physical delivery, financial settlement, or only budgeting?
+- Does it publish confidence, coverage, or data sufficiency indicators?
+- Does it disclose AILIS layer coverage?
+
+## Instrument Types
+
+| Instrument | Possible use | Main residual risk |
+| --- | --- | --- |
+| Spot GPU rental index | Procurement benchmark and budget reference. | SKU, region, term, and workload mismatch. |
+| Forward curve | Budgeting, underwriting, OTC swaps, contract negotiation. | Methodology and liquidity risk; curve may not imply deliverable capacity. |
+| Fixed-for-floating compute swap | Hedge rental-rate exposure. | Index basis, credit, collateral, and settlement governance. |
+| Physical forward | Reserve future capacity. | Delivery failure, substitution, power delay, and counterparty risk. |
+| Outage insurance | Cover business interruption beyond service credits. | Loss measurement, exclusions, and dependency mapping. |
+| GPU residual value insurance | Support GPU-backed lending or fleet finance. | Technology obsolescence, secondary-market depth, export controls, and benchmark fit. |
+| Power-compute spread hedge | Link energy cost to compute revenue or capacity. | Regional basis, grid constraints, and curtailment rules. |
+
+## AILIS Layer Coverage Statement
+
+A compute contract or benchmark could include a short layer coverage statement:
+
+| Layer | Covered? | Notes |
+| --- | --- | --- |
+| L0 Facilities and Power | Yes/No/Partial | Region, power source, bridge power, interconnection, cooling. |
+| L1 Compute Fabric | Yes/No/Partial | SKU, memory, interconnect, topology. |
+| L2 Runtime | Yes/No/Partial | Driver, firmware, virtualization, container. |
+| L3 Graph and Compilation | Yes/No/Partial | Compiler/runtime expectations, optimized kernels. |
+| L4 Numeric | Yes/No/Partial | Supported precisions and quantization assumptions. |
+| L5-L9 Data and Context | Yes/No/Partial | Data locality, context, retrieval, cache/storage. |
+| L10-L14 Flow and State | Yes/No/Partial | Routing, transport, identity, session continuity. |
+| L15 Governance and Schema | Yes/No/Partial | Compliance, audit, benchmark governance, sovereignty. |
+| L16 Domain Logic | Yes/No/Partial | Workload outcome or application SLA. |
+
+This would not make the contract perfect. It would make hidden exclusions easier to discuss.
+
+## Example Reads
+
+### GPU Forward Curve
+
+Silicon Data describes a GPU forward curve built from rental term structures and no-arbitrage forward derivation. This appears useful for pricing expectations, procurement timing, and financial products. The AILIS question is what layer coverage the curve has: SKU and term may be covered; power, topology, software stack, sovereignty, and workload outcome may remain outside the curve unless separately specified.
+
+### Compute Risk Transfer
+
+Forward Compute describes insurance, swaps, forwards, and purpose-built indices for compute. This maps naturally to L15 governance and L11 addressing/registry questions: what is the settlement reference, what data supports it, and what exactly is insured or hedged?
+
+### Power-Flexible AI Factories
+
+NVIDIA and Emerald AI's March 2026 announcement reframes some AI factories as flexible grid assets rather than passive loads. That suggests a contract category where L0 flexibility is not a side issue; it is part of the economic unit.
+
+### Sovereign Private Cloud
+
+Microsoft's February 2026 sovereign cloud announcement shows why some compute cannot simply be replaced by cheaper public cloud supply. The deliverable includes operational boundary, local control, governance, and disconnected operation.
+
+## Questions For Review
+
+- Should AILIS publish a formal "Compute Capacity Contract Checklist" as a reference artifact?
+- Would benchmark administrators be willing to state layer coverage?
+- Which attributes are essential for a minimal compute forward contract?
+- Are token-throughput contracts more economically meaningful than GPU-hour contracts, or too workload-specific?
+- How should outage insurance map dependencies across L0-L16?
+- What role could open-source telemetry play in settlement verification?
+
+## Sources
+
+- Andrew Schwartz, [Enron's Missed Opportunity](https://brie.berkeley.edu/sites/default/files/wp152.pdf), Berkeley Roundtable on the International Economy, 2002/2003.
+- Silicon Data, [GPU Forward Curve](https://www.silicondata.com/products/forward-curve), accessed May 7, 2026.
+- Silicon Data, [The GPU Forward Curve: Pricing the Curve, Not Just the Spot](https://www.silicondata.com/blog/the-gpu-forward-curve-pricing-the-curve-not-just-the-spot), May 1, 2026.
+- Forward Compute, [Insurance and financial derivatives for compute](https://www.forwardcompute.ai/), accessed May 7, 2026.
+- Financial Stability Board, [IOSCO Principles for Financial Benchmarks](https://www.fsb.org/2013/07/cos_130717/), July 17, 2013.
+- CFTC, [Designated Contract Markets](https://www.cftc.gov/IndustryOversight/TradingOrganizations/DCMs/index.htm), accessed May 7, 2026.
+- CFTC, [Economic Requirements](https://www.cftc.gov/IndustryOversight/ContractsProducts/EconomicRequirements/index.htm), accessed May 7, 2026.
+- NVIDIA, [Flexible AI Factories as Grid Assets](https://investor.nvidia.com/news/press-release-details/2026/NVIDIA-and-Emerald-AI-Join-Leading-Energy-Companies-to-Pioneer-Flexible-AI-Factories-as-Grid-Assets/default.aspx), Mar. 23, 2026.
+- Microsoft, [Sovereign Cloud adds disconnected large-model support](https://blogs.microsoft.com/blog/2026/02/24/microsoft-sovereign-cloud-adds-governance-productivity-and-support-for-large-ai-models-securely-running-even-when-completely-disconnected/), Feb. 24, 2026.

--- a/studies/index.md
+++ b/studies/index.md
@@ -1,5 +1,7 @@
 # Case Studies
 
+<!-- markdownlint-disable MD013 MD033 -->
+
 Real-world examples of applying the AILIS framework to understand and analyze AI systems.
 
 <div class="ailis-case-study-feature">

--- a/studies/index.md
+++ b/studies/index.md
@@ -2,32 +2,52 @@
 
 Real-world examples of applying the AILIS framework to understand and analyze AI systems.
 
-<div class="ailis-case-study-feature" markdown="1">
+<div class="ailis-case-study-feature">
 
-<div class="ailis-case-study-lead lane-research" markdown="1">
-<span class="ailis-card-kicker">Featured case study</span>
+<article class="ailis-case-study-lead lane-research">
+  <span class="ailis-card-kicker">Featured case study</span>
+  <h2><a href="dollhouse-public-stack-mapping.md">Mapping the public Dollhouse Research portfolio into AILIS</a></h2>
+  <p>A concrete pass across the current public Dollhouse Research stack, including DollhouseMCP, MCP-AQL, Dollhouse Collection, Elemental Surveys, and Merview.</p>
+  <a class="ailis-case-study-cta" href="dollhouse-public-stack-mapping.md">Open the case study</a>
+</article>
 
-## [Mapping the public Dollhouse Research portfolio into AILIS](dollhouse-public-stack-mapping.md)
-
-A concrete pass across the current public Dollhouse Research stack,
-including DollhouseMCP, MCP-AQL, Dollhouse Collection, Elemental Surveys,
-and Merview.
-
-[Open the case study](dollhouse-public-stack-mapping.md)
-</div>
-
-<div class="ailis-case-study-side lane-research" markdown="1">
-<span class="ailis-card-kicker">Portfolio scope</span>
-
-- [**Dollhouse Research**<span>Parent research organization</span>](dollhouse-public-stack-mapping.md#dollhouse-research)
-- [**DollhouseMCP**<span>Core platform and runtime surface</span>](dollhouse-public-stack-mapping.md#dollhousemcp)
-- [**MCP-AQL**<span>Spec, adapters, and generator tooling</span>](dollhouse-public-stack-mapping.md#mcp-aql-spec)
-- [**Dollhouse Collection**<span>Catalog and activation product</span>](dollhouse-public-stack-mapping.md#dollhouse-collection)
-- [**Elemental Surveys**<span>Applied research workflow</span>](dollhouse-public-stack-mapping.md#elemental-surveys)
-- [**Merview**<span>Companion utility and review surface</span>](dollhouse-public-stack-mapping.md#merview)
-{: .ailis-case-study-list }
+<aside class="ailis-case-study-side lane-research">
+  <span class="ailis-card-kicker">Portfolio scope</span>
+  <ul class="ailis-case-study-list">
+    <li><a href="dollhouse-public-stack-mapping.md#dollhouse-research"><strong>Dollhouse Research</strong><span>Parent research organization</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping.md#dollhousemcp"><strong>DollhouseMCP</strong><span>Core platform and runtime surface</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping.md#mcp-aql-spec"><strong>MCP-AQL</strong><span>Spec, adapters, and generator tooling</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping.md#dollhouse-collection"><strong>Dollhouse Collection</strong><span>Catalog and activation product</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping.md#elemental-surveys"><strong>Elemental Surveys</strong><span>Applied research workflow</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping.md#merview"><strong>Merview</strong><span>Companion utility and review surface</span></a></li>
+  </ul>
+</aside>
 
 </div>
+
+## Compute Market Research
+
+These newer drafts use AILIS as a lens for the emerging compute-market discussion:
+
+<div class="ailis-case-study-card-grid">
+
+<article class="ailis-case-study-card lane-core">
+  <span class="ailis-card-kicker">Layered market framing</span>
+  <h3><a href="compute-as-layered-market.md">Compute as a Layered Market</a></h3>
+  <p>Why compute financialization might depend on which layers are standardized, priced, and ignored.</p>
+</article>
+
+<article class="ailis-case-study-card lane-protocol">
+  <span class="ailis-card-kicker">Analytical model</span>
+  <h3><a href="compute-basis-risk-model.md">A Layered Basis Risk Model for Compute Capacity</a></h3>
+  <p>A draft quality-adjusted compute model for analyzing hedge and capacity mismatch.</p>
+</article>
+
+<article class="ailis-case-study-card lane-research">
+  <span class="ailis-card-kicker">Market structure checklist</span>
+  <h3><a href="compute-market-structure-checklist.md">Compute Capacity Contract and Benchmark Checklist</a></h3>
+  <p>A practical checklist for contracts, benchmarks, swaps, forwards, and insurance products.</p>
+</article>
 
 </div>
 


### PR DESCRIPTION
## Summary

- Adds three AILIS case-study/research draft pages on compute as a layered market, compute basis risk, and compute capacity contract/benchmark design.
- Updates the Case Studies index to surface the new compute-market pages as cards.
- Fixes the Case Studies feature-card rendering bug by using explicit HTML for the portfolio scope list and scoping CTA styling away from the title link.
- Adds a session note for the DollhouseMCP compute-market analyst ensemble and research pass.

## Why

The compute-market discussion is current, and the new drafts show how AILIS can help separate power, compute fabric, memory, software efficiency, governance, and market-structure effects instead of treating compute as one flat commodity.

The index fix addresses the visual issue where project names and descriptions ran together and the featured title wrapped awkwardly.

## Validation

- `git diff --cached --check`
- `/tmp/ailis-mkdocs-venv311/bin/python -m mkdocs build`
- `/tmp/ailis-mkdocs-venv311/bin/python -m mkdocs build --strict`
- Browser verification of `/AILIS/studies/` at desktop and mobile widths with Playwright
- Opened `/AILIS/studies/compute-as-layered-market/` locally to confirm the new page resolves
