### PR TITLE
[codex] repair case study links and code fences

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ markdown_extensions:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
+      use_pygments: false
   - pymdownx.inlinehilite
   - pymdownx.keys
   - pymdownx.mark
@@ -204,8 +205,7 @@ markdown_extensions:
   - pymdownx.snippets:
       auto_append:
         - includes/abbreviations.md
-  # Render top-level fenced code blocks.
-  - fenced_code
+  - pymdownx.superfences
 
 # Extra CSS and JavaScript
 extra_css:

--- a/studies/index.md
+++ b/studies/index.md
@@ -8,20 +8,20 @@ Real-world examples of applying the AILIS framework to understand and analyze AI
 
 <article class="ailis-case-study-lead lane-research">
   <span class="ailis-card-kicker">Featured case study</span>
-  <h2><a href="dollhouse-public-stack-mapping.md">Mapping the public Dollhouse Research portfolio into AILIS</a></h2>
+  <h2><a href="dollhouse-public-stack-mapping/">Mapping the public Dollhouse Research portfolio into AILIS</a></h2>
   <p>A concrete pass across the current public Dollhouse Research stack, including DollhouseMCP, MCP-AQL, Dollhouse Collection, Elemental Surveys, and Merview.</p>
-  <a class="ailis-case-study-cta" href="dollhouse-public-stack-mapping.md">Open the case study</a>
+  <a class="ailis-case-study-cta" href="dollhouse-public-stack-mapping/">Open the case study</a>
 </article>
 
 <aside class="ailis-case-study-side lane-research">
   <span class="ailis-card-kicker">Portfolio scope</span>
   <ul class="ailis-case-study-list">
-    <li><a href="dollhouse-public-stack-mapping.md#dollhouse-research"><strong>Dollhouse Research</strong><span>Parent research organization</span></a></li>
-    <li><a href="dollhouse-public-stack-mapping.md#dollhousemcp"><strong>DollhouseMCP</strong><span>Core platform and runtime surface</span></a></li>
-    <li><a href="dollhouse-public-stack-mapping.md#mcp-aql-spec"><strong>MCP-AQL</strong><span>Spec, adapters, and generator tooling</span></a></li>
-    <li><a href="dollhouse-public-stack-mapping.md#dollhouse-collection"><strong>Dollhouse Collection</strong><span>Catalog and activation product</span></a></li>
-    <li><a href="dollhouse-public-stack-mapping.md#elemental-surveys"><strong>Elemental Surveys</strong><span>Applied research workflow</span></a></li>
-    <li><a href="dollhouse-public-stack-mapping.md#merview"><strong>Merview</strong><span>Companion utility and review surface</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#dollhouse-research"><strong>Dollhouse Research</strong><span>Parent research organization</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#dollhousemcp"><strong>DollhouseMCP</strong><span>Core platform and runtime surface</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#mcp-aql-spec"><strong>MCP-AQL</strong><span>Spec, adapters, and generator tooling</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#dollhouse-collection"><strong>Dollhouse Collection</strong><span>Catalog and activation product</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#elemental-surveys"><strong>Elemental Surveys</strong><span>Applied research workflow</span></a></li>
+    <li><a href="dollhouse-public-stack-mapping/#merview"><strong>Merview</strong><span>Companion utility and review surface</span></a></li>
   </ul>
 </aside>
 
@@ -35,19 +35,19 @@ These newer drafts use AILIS as a lens for the emerging compute-market discussio
 
 <article class="ailis-case-study-card lane-core">
   <span class="ailis-card-kicker">Layered market framing</span>
-  <h3><a href="compute-as-layered-market.md">Compute as a Layered Market</a></h3>
+  <h3><a href="compute-as-layered-market/">Compute as a Layered Market</a></h3>
   <p>Why compute financialization might depend on which layers are standardized, priced, and ignored.</p>
 </article>
 
 <article class="ailis-case-study-card lane-protocol">
   <span class="ailis-card-kicker">Analytical model</span>
-  <h3><a href="compute-basis-risk-model.md">A Layered Basis Risk Model for Compute Capacity</a></h3>
+  <h3><a href="compute-basis-risk-model/">A Layered Basis Risk Model for Compute Capacity</a></h3>
   <p>A draft quality-adjusted compute model for analyzing hedge and capacity mismatch.</p>
 </article>
 
 <article class="ailis-case-study-card lane-research">
   <span class="ailis-card-kicker">Market structure checklist</span>
-  <h3><a href="compute-market-structure-checklist.md">Compute Capacity Contract and Benchmark Checklist</a></h3>
+  <h3><a href="compute-market-structure-checklist/">Compute Capacity Contract and Benchmark Checklist</a></h3>
   <p>A practical checklist for contracts, benchmarks, swaps, forwards, and insurance products.</p>
 </article>
 


### PR DESCRIPTION
## Summary

This hotfix repairs the production rendering regressions from the compute case-study PR.

- Change raw HTML case-study card links from `.md` paths to generated directory URLs so MkDocs/GitHub Pages serves the pages correctly.
- Restore `pymdownx.superfences` so indented and nested fenced code blocks continue to render.
- Disable the Pygments path for `pymdownx.highlight`, which was the local failure mode that caused `superfences` to miss top-level fences in this build environment.

## Validation

- `/tmp/ailis-mkdocs-venv311/bin/python -m mkdocs build --strict --clean`
- `npx --yes markdownlint-cli@0.45.0 studies/index.md --config .github/markdownlint.json`
- `git diff --check`
- Browser smoke check against the built site:
  - Case-study card area has 11 links and zero `.md` links.
  - `studies/compute-basis-risk-model/` has rendered code blocks and no literal ```yaml text.
  - `security/SECURITY_AUDIT_REPORT_2025_09_16/` preserves nested YAML fences as rendered code blocks.